### PR TITLE
feature: Add an API that can switch audio if there is a secondary audio stream

### DIFF
--- a/d.ts/mpegts.d.ts
+++ b/d.ts/mpegts.d.ts
@@ -345,6 +345,8 @@ declare namespace Mpegts {
     interface MSEPlayer extends Player {
         mediaInfo: MSEPlayerMediaInfo;
         statisticsInfo: MSEPlayerStatisticsInfo;
+        switchPrimaryAudio(): void;
+        switchSecondaryAudio(): void;
     }
 
     interface NativePlayer extends Player {

--- a/d.ts/src/demux/ts-demuxer.d.ts
+++ b/d.ts/src/demux/ts-demuxer.d.ts
@@ -26,6 +26,7 @@ declare class TSDemuxer extends BaseDemuxer {
     private audio_metadata_changed_;
     private video_track_;
     private audio_track_;
+    preferred_secondary_audio: boolean;
     constructor(probe_data: any, config: any);
     destroy(): void;
     static probe(buffer: ArrayBuffer): {

--- a/src/core/transmuxer.js
+++ b/src/core/transmuxer.js
@@ -24,6 +24,7 @@ import TransmuxingController from './transmuxing-controller.js';
 import TransmuxingEvents from './transmuxing-events.js';
 import TransmuxingWorker from './transmuxing-worker.js';
 import MediaInfo from './media-info.js';
+import TSDemuxer from '../demux/ts-demuxer.ts';
 
 class Transmuxer {
 
@@ -135,6 +136,26 @@ class Transmuxer {
             this._worker.postMessage({cmd: 'resume'});
         } else {
             this._controller.resume();
+        }
+    }
+
+    switchPrimaryAudio() {
+        if (this._worker) {
+            this._worker.postMessage({cmd: 'switch_audio', param: 'primary'});
+        } else {
+            if (this._controller._demuxer instanceof TSDemuxer) {
+                this._controller._demuxer.preferred_secondary_audio = false;
+            }
+        }
+    }
+
+    switchSecondaryAudio() {
+        if (this._worker) {
+            this._worker.postMessage({cmd: 'switch_audio', param: 'secondary'});
+        } else {
+            if (this._controller._demuxer instanceof TSDemuxer) {
+                this._controller._demuxer.preferred_secondary_audio = true;
+            }
         }
     }
 

--- a/src/core/transmuxing-worker.js
+++ b/src/core/transmuxing-worker.js
@@ -21,6 +21,7 @@ import LoggingControl from '../utils/logging-control.js';
 import Polyfill from '../utils/polyfill.js';
 import TransmuxingController from './transmuxing-controller.js';
 import TransmuxingEvents from './transmuxing-events.js';
+import TSDemuxer from '../demux/ts-demuxer.ts';
 
 /* post message to worker:
    data: {
@@ -95,6 +96,15 @@ let TransmuxingWorker = function (self) {
                 }
                 break;
             }
+            case 'switch_audio':
+                if (controller._demuxer instanceof TSDemuxer) {
+                    if (e.data.param === 'primary') {
+                        controller._demuxer.preferred_secondary_audio = false;
+                    } else if (e.data.param === 'secondary') {
+                        controller._demuxer.preferred_secondary_audio = true;
+                    }
+                }
+                break;
         }
     });
 

--- a/src/demux/ts-demuxer.ts
+++ b/src/demux/ts-demuxer.ts
@@ -85,6 +85,8 @@ class TSDemuxer extends BaseDemuxer {
     private video_track_ = {type: 'video', id: 1, sequenceNumber: 0, samples: [], length: 0};
     private audio_track_ = {type: 'audio', id: 2, sequenceNumber: 0, samples: [], length: 0};
 
+    public preferred_secondary_audio = false;
+
     public constructor(probe_data: any, config: any) {
         super();
 
@@ -440,7 +442,7 @@ class TSDemuxer extends BaseDemuxer {
 
             if (stream_type === StreamType.kH264 && !pmt.common_pids.h264) {
                 pmt.common_pids.h264 = elementary_PID;
-            } else if (stream_type === StreamType.kADTSAAC && !pmt.common_pids.adts_aac) {
+            } else if (stream_type === StreamType.kADTSAAC && (!pmt.common_pids.adts_aac || this.preferred_secondary_audio)) {
                 pmt.common_pids.adts_aac = elementary_PID;
             } else if (stream_type === StreamType.kPESPrivateData) {
                 pmt.pes_private_data_pids[elementary_PID] = true;

--- a/src/player/mse-player.js
+++ b/src/player/mse-player.js
@@ -298,11 +298,15 @@ class MSEPlayer {
     }
 
     switchPrimaryAudio() {
-        this._transmuxer._controller._demuxer.preferred_secondary_audio = false;
+        if (this._transmuxer._controller._demuxer !== null) {
+            this._transmuxer._controller._demuxer.preferred_secondary_audio = false;
+        }
     }
 
     switchSecondaryAudio() {
-        this._transmuxer._controller._demuxer.preferred_secondary_audio = true;
+        if (this._transmuxer._controller._demuxer !== null) {
+            this._transmuxer._controller._demuxer.preferred_secondary_audio = true;
+        }
     }
 
     get type() {

--- a/src/player/mse-player.js
+++ b/src/player/mse-player.js
@@ -297,6 +297,14 @@ class MSEPlayer {
         this._mediaElement.pause();
     }
 
+    switchPrimaryAudio() {
+        this._transmuxer._controller._demuxer.preferred_secondary_audio = false;
+    }
+
+    switchSecondaryAudio() {
+        this._transmuxer._controller._demuxer.preferred_secondary_audio = true;
+    }
+
     get type() {
         return this._type;
     }

--- a/src/player/mse-player.js
+++ b/src/player/mse-player.js
@@ -298,15 +298,11 @@ class MSEPlayer {
     }
 
     switchPrimaryAudio() {
-        if (this._transmuxer._controller._demuxer !== null) {
-            this._transmuxer._controller._demuxer.preferred_secondary_audio = false;
-        }
+        this._transmuxer.switchPrimaryAudio();
     }
 
     switchSecondaryAudio() {
-        if (this._transmuxer._controller._demuxer !== null) {
-            this._transmuxer._controller._demuxer.preferred_secondary_audio = true;
-        }
+        this._transmuxer.switchSecondaryAudio()
     }
 
     get type() {


### PR DESCRIPTION
known issues: If you run switchSecondaryAudio() when there is a secondary audio stream but no data is streaming, playback will stop. Even then, run switchPrimaryAudio() will cause it to play again.