### PR TITLE
feat: support latency chasing by changing playbackRate

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -74,6 +74,9 @@ In multipart mode, `duration` `filesize` `url` field in `MediaDataSource` struct
 | `liveBufferLatencyChasing?`      | `boolean` | `false`                      | Chasing the live stream latency caused by the internal buffer in HTMLMediaElement. `isLive` should also be set to `true` |
 | `liveBufferLatencyMaxLatency?`   | `number`  | `1.5`                        | Maximum acceptable buffer latency in HTMLMediaElement, in seconds. Effective only if `isLive: true` and `liveBufferLatencyChasing: true` |
 | `liveBufferLatencyMinRemain?`    | `number`  | `0.5`                        | Minimum buffer latency to be keeped in HTMLMediaElement, in seconds. Effective only if `isLive: true` and `liveBufferLatencyChasing: true` |
+| `liveSync?`                      | `boolean` | `false`                      | Chasing the live stream latency caused by the internal buffer in HTMLMediaElement by changing the playbackRate. `isLive` should also be set to `true` |
+| `liveSyncMaxLatency`             | `number`  | `1`                          | Maximum acceptable buffer latency in HTMLMediaElement, in seconds. Effective only if `isLive: true` and `liveSync: true` |
+| `liveSyncPlaybackRate`           | `number`  | `1.2`                        | PlaybackRate limited between [1, 2] will be used for latency chasing. Effective only if `isLive: true` and `liveSync: true` |
 | `lazyLoad?`                      | `boolean` | `true`                       | Abort the http connection if there's enough data for playback. |
 | `lazyLoadMaxDuration?`           | `number`  | `3 * 60`                     | Indicates how many seconds of data to be kept for `lazyLoad`. |
 | `lazyLoadRecoverDuration?`       | `number`  | `30`                         | Indicates the `lazyLoad` recover time boundary in seconds. |

--- a/src/config.js
+++ b/src/config.js
@@ -27,6 +27,10 @@ export const defaultConfig = {
     liveBufferLatencyMaxLatency: 1.5,
     liveBufferLatencyMinRemain: 0.5,
 
+    liveSync: false,
+    liveSyncMaxLatency: 1,
+    liveSyncPlaybackRate: 1.2,
+
     lazyLoad: true,
     lazyLoadMaxDuration: 3 * 60,
     lazyLoadRecoverDuration: 30,

--- a/src/player/mse-player.js
+++ b/src/player/mse-player.js
@@ -184,6 +184,7 @@ class MSEPlayer {
             this._mediaElement.removeEventListener('canplay', this.e.onvCanPlay);
             this._mediaElement.removeEventListener('stalled', this.e.onvStalled);
             this._mediaElement.removeEventListener('progress', this.e.onvProgress);
+            this._mediaElement.removeEventListener('timeupdate', this.e.onvTimeupdate);
             this._mediaElement = null;
         }
         if (this._msectl) {

--- a/src/player/mse-player.js
+++ b/src/player/mse-player.js
@@ -57,7 +57,8 @@ class MSEPlayer {
             onvSeeking: this._onvSeeking.bind(this),
             onvCanPlay: this._onvCanPlay.bind(this),
             onvStalled: this._onvStalled.bind(this),
-            onvProgress: this._onvProgress.bind(this)
+            onvProgress: this._onvProgress.bind(this),
+            onvTimeupdate: this._onvTimeupdate.bind(this),
         };
 
         if (self.performance && self.performance.now) {
@@ -139,6 +140,9 @@ class MSEPlayer {
         mediaElement.addEventListener('canplay', this.e.onvCanPlay);
         mediaElement.addEventListener('stalled', this.e.onvStalled);
         mediaElement.addEventListener('progress', this.e.onvProgress);
+        if (this._config.isLive && this._config.liveSync) {
+            mediaElement.addEventListener('timeupdate', this.e.onvTimeupdate);
+        }
 
         this._msectl = new MSEController(this._config);
 
@@ -353,6 +357,21 @@ class MSEPlayer {
         }
         this._statisticsInfo = this._fillStatisticsInfo(this._statisticsInfo);
         return Object.assign({}, this._statisticsInfo);
+    }
+
+    get latency() {
+        if (!this._mediaElement) {
+            return 0;
+        }
+        let buffered = this._mediaElement.buffered;
+        let currentTime = this._mediaElement.currentTime;
+
+        if (buffered.length > 0) {
+            let buffered_end = buffered.end(buffered.length - 1);
+            return buffered_end - currentTime;
+        }
+
+        return 0;
     }
 
     _fillStatisticsInfo(statInfo) {
@@ -637,6 +656,16 @@ class MSEPlayer {
         this._checkAndResumeStuckPlayback();
     }
 
+    _onvTimeupdate(e) {
+        const latency = this.latency;
+
+        if (latency > this._config.liveSyncMaxLatency + 0.05) {
+            const playbackRate = Math.min(2, Math.max(1, this._config.liveSyncPlaybackRate));
+            this._mediaElement.playbackRate = playbackRate;
+        } else if (this._mediaElement.playbackRate !== 1 && this._mediaElement.playbackRate !== 0) {
+            this._mediaElement.playbackRate = 1;
+        }
+    }
 }
 
 export default MSEPlayer;


### PR DESCRIPTION
Inspired by <https://github.com/video-dev/hls.js/blob/master/src/controller/latency-controller.ts#L192>.
Increasing `playbackRate` to some small value will not interrupt user's experience, but keeping latency in low.