### PR TITLE
Update h265-parser.js

### DIFF
--- a/src/demux/h265-parser.js
+++ b/src/demux/h265-parser.js
@@ -279,11 +279,12 @@ class H265NaluParser {
                         let commonInfPresentFlag = 1;
                         let nal_hrd_parameters_present_flag = false;
                         let vcl_hrd_parameters_present_flag = false;
+                        let sub_pic_hrd_params_present_flag = false;
                         if (commonInfPresentFlag) {
                             nal_hrd_parameters_present_flag = gb.readBool();
                             vcl_hrd_parameters_present_flag = gb.readBool();
                             if( nal_hrd_parameters_present_flag || vcl_hrd_parameters_present_flag ){
-                                let sub_pic_hrd_params_present_flag = gb.readBool();
+                                sub_pic_hrd_params_present_flag = gb.readBool();
                                 if (sub_pic_hrd_params_present_flag) {
                                     gb.readByte();
                                     gb.readBits(5);


### PR DESCRIPTION
fix 'sub_pic_hrd_params_present_flag' is not defined.