### PR TITLE
Add and fire player destroying events

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -188,19 +188,20 @@ interface LoggingControl {
 
 A series of constants that can be used with `Player.on()` / `Player.off()`. They require the prefix `mpegts.Events`.
 
-| Event               | Description                              |
-| ------------------- | ---------------------------------------- |
-| ERROR               | An error occurred by any cause during the playback |
-| LOADING_COMPLETE    | The input MediaDataSource has been completely buffered to end |
-| RECOVERED_EARLY_EOF | An unexpected network EOF occurred during buffering but automatically recovered |
-| MEDIA_INFO          | Provides technical information of the media like video/audio codec, bitrate, etc. |
-| METADATA_ARRIVED    | Provides metadata which FLV file(stream) can contain with an "onMetaData" marker.  |
-| SCRIPTDATA_ARRIVED  | Provides scriptdata (OnCuePoint / OnTextData) which FLV file(stream) can contain. |
-| TIMED_ID3_METADATA_ARRIVED |  Provides Timed ID3 Metadata packets containing private data (stream_type=0x15) callback |
-| SMPTE2038_METADATA_ARRIVED |  Provides SMPTE2038 Metadata packets containing private data callback |
-| SCTE35_METADATA_ARRIVED |  Provides SCTE35 Metadata packets containing section (stream_type=0x86) callback |
-| PES_PRIVATE_DATA_ARRIVED | Provides ISO/IEC 13818-1 PES packets containing private data (stream_type=0x06) callback |
-| STATISTICS_INFO     | Provides playback statistics information like dropped frames, current speed, etc. |
+| Event                      | Description                              |
+| -------------------------- | ---------------------------------------- |
+| ERROR                      | An error occurred by any cause during the playback |
+| LOADING_COMPLETE           | The input MediaDataSource has been completely buffered to end |
+| RECOVERED_EARLY_EOF        | An unexpected network EOF occurred during buffering but automatically recovered |
+| MEDIA_INFO                 | Provides technical information of the media like video/audio codec, bitrate, etc. |
+| METADATA_ARRIVED           | Provides metadata which FLV file(stream) can contain with an "onMetaData" marker.  |
+| SCRIPTDATA_ARRIVED         | Provides scriptdata (OnCuePoint / OnTextData) which FLV file(stream) can contain. |
+| TIMED_ID3_METADATA_ARRIVED | Provides Timed ID3 Metadata packets containing private data (stream_type=0x15) callback |
+| SMPTE2038_METADATA_ARRIVED | Provides SMPTE2038 Metadata packets containing private data callback |
+| SCTE35_METADATA_ARRIVED    | Provides SCTE35 Metadata packets containing section (stream_type=0x86) callback |
+| PES_PRIVATE_DATA_ARRIVED   | Provides ISO/IEC 13818-1 PES packets containing private data (stream_type=0x06) callback |
+| STATISTICS_INFO            | Provides playback statistics information like dropped frames, current speed, etc. |
+| DESTROYING                 | Fired when the player begins teardown |
 
 ### mpegts.ErrorTypes
 

--- a/src/player/mse-player.js
+++ b/src/player/mse-player.js
@@ -94,6 +94,7 @@ class MSEPlayer {
     }
 
     destroy() {
+        this._emitter.emit(PlayerEvents.DESTROYING);
         if (this._progressChecker != null) {
             window.clearInterval(this._progressChecker);
             this._progressChecker = null;

--- a/src/player/native-player.js
+++ b/src/player/native-player.js
@@ -58,6 +58,7 @@ class NativePlayer {
     }
 
     destroy() {
+        this._emitter.emit(PlayerEvents.DESTROYING);
         if (this._mediaElement) {
             this.unload();
             this.detachMediaElement();

--- a/src/player/player-events.js
+++ b/src/player/player-events.js
@@ -28,7 +28,8 @@ const PlayerEvents = {
     SCTE35_METADATA_ARRIVED: 'scte35_metadata_arrived',
     PES_PRIVATE_DATA_DESCRIPTOR: 'pes_private_data_descriptor',
     PES_PRIVATE_DATA_ARRIVED: 'pes_private_data_arrived',
-    STATISTICS_INFO: 'statistics_info'
+    STATISTICS_INFO: 'statistics_info',
+    DESTROYING: 'destroying'
 };
 
 export default PlayerEvents;


### PR DESCRIPTION
This allows consumers to know when the player is beginning teardown.