### PR TITLE
fix: skip duplicated P frame

### DIFF
--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -1407,6 +1407,16 @@ class FLVDemuxer {
 
             if (unitType === 5) {  // IDR
                 keyframe = true;
+            } else if (unitType === 1 && units.length > 0) { // P frame
+                const lastUnit = units[units.length - 1];
+                if (lastUnit.type === unitType) {
+                    if (/macintosh/ig.test(window.navigator.userAgent) || /Mac OS/ig.test(window.navigator.userAgent)) {
+                        Log.w(this.TAG, `Skip multiple P frame Nalus in one video packet (dts: ${dts})`);
+                        break;
+                    } else {
+                        Log.w(this.TAG, `Found multiple P frame Nalus in one video packet (dts: ${dts})`);
+                    }
+                }
             }
 
             let data = new Uint8Array(arrayBuffer, dataOffset + offset, lengthSize + naluSize);


### PR DESCRIPTION
如果说，一个 Flv Video Tag 中包含了多个 P frame，在 Mac 上播放时会失败；因此可以判断这种情况，然后忽略掉多余的 frame
![image](https://github.com/xqq/mpegts.js/assets/17154608/d1d05b55-152c-49a4-b872-be5617c8a0cc)
