### PR TITLE
Update README.md to mention working on newer iOS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ mpegts.js could be tested with [Simple Realtime Server](https://github.com/ossrs
 ## Limitations
 - mpeg2video is not supported
 - HTTP MPEG2-TS live stream could not work on old browsers like IE11
-- mpegts.js is not usable on iOS caused by the banning of [Media Source Extensions][] (available on iPadOS)
+- mpegts.js is not usable on iOS version 17.0 or older caused by the banning of [Media Source Extensions][] (available on iPadOS), iOS 17.1 works through Managed Media Source API
 
 ## Features inherited from flv.js
 - FLV container with H.264 + AAC / MP3 codec playback


### PR DESCRIPTION
Mpegts.js works with newer iOS versions (17.1 and later) thanks to supporting Managed Media Source API.