### PR TITLE
fix safari cannot play ts file problem.

### DIFF
--- a/src/core/mse-controller.js
+++ b/src/core/mse-controller.js
@@ -226,6 +226,9 @@ class MSEController {
         let is = initSegment;
         let mimeType = `${is.container}`;
         if (is.codec && is.codec.length > 0) {
+            if (is.codec === 'opus' && Browser.safari) {
+                is.codec = 'Opus';
+            }
             mimeType += `;codecs=${is.codec}`;
         }
 


### PR DESCRIPTION
## Bug: ##
MacOS safari can't play TS file.

## steps to reproduce ##
1. clone this project `https://github.com/xqq/mpegts.js`, and build the project, (check the README).
     `npm install; npm install -g webpack-cli; npm run build`;
2. run the webpack serve: `npm run serve`;
3. access page `http://localhost:8080/arib.html` in safari;
4. find/generate a `test.ts` file with audio codec as `opus`;
    e.g. by ffmpeg: `ffmpeg -i [file].[aac|opus] -acodec opus test.ts`
5. start a static web server in the folder of `test.ts`,
    e.g. by this python script: `https://gist.github.com/mkows/cd2122f427ea722bf41aa169ef762001`
    `python server-cors.py 9921`
6. in page `http://localhost:8080/arib.html`, input Stream URL as: `http://127.0.0.1:9921/test.ts`, deselect `isLive` & `withCredentials` & `liveSync` checkbox. then click `Load` button.
7. the `opus` audio can not play in safari.

## Root Cause ##
the Safari web browser don't support MIME `audio/mp4;codecs=opus`, but support `audio/mp4;codecs=Opus`.

In side safari web dev tools, go to `Console` tab. Input `MediaSource.isTypeSupported('audio/mp4;codecs=opus')` and `MediaSource.isTypeSupported('audio/mp4;codecs=Opus')` to verify.

