### PR TITLE
Support 'dropSEI' config for flv-demuxer

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ export const defaultConfig = {
     statisticsInfoReportInterval: 600,
 
     fixAudioTimestampGap: true,
+    dropSEI: false,
 
     accurateSeek: false,
     seekType: 'range',  // [range, param, custom]

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -1668,10 +1668,14 @@ class FLVDemuxer {
                 keyframe = true;
             }
 
-            let data = new Uint8Array(arrayBuffer, dataOffset + offset, lengthSize + naluSize);
-            let unit = {type: unitType, data: data};
-            units.push(unit);
-            length += data.byteLength;
+            if (this._config.dropSEI && unitType === 6) { // SEI
+                // skip SEI Nalu
+            } else {
+                let data = new Uint8Array(arrayBuffer, dataOffset + offset, lengthSize + naluSize);
+                let unit = {type: unitType, data: data};
+                units.push(unit);
+                length += data.byteLength;
+            }
 
             offset += lengthSize + naluSize;
         }

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -1730,10 +1730,14 @@ class FLVDemuxer {
                 keyframe = true;
             }
 
-            let data = new Uint8Array(arrayBuffer, dataOffset + offset, lengthSize + naluSize);
-            let unit = {type: unitType, data: data};
-            units.push(unit);
-            length += data.byteLength;
+            if (this._config.dropSEI && (uintType === 39 || uintType === 40)) { // SEI
+                // drop SEI Nalu
+            } else {
+                let data = new Uint8Array(arrayBuffer, dataOffset + offset, lengthSize + naluSize);
+                let unit = {type: unitType, data: data};
+                units.push(unit);
+                length += data.byteLength;
+            }
 
             offset += lengthSize + naluSize;
         }


### PR DESCRIPTION
Some http-flv streams may carry private SEI nalu, which may cause browser (like Chrome) hardware decode fail and throw PIPELINE_DECODE_ERROR.

For better compatibility with http-flv streams, introduce `dropSEI` config to skip SEI nalu.