### PR TITLE
fix: improve MediaSource and ManagedMediaSource detection method

### DIFF
--- a/src/core/mse-controller.js
+++ b/src/core/mse-controller.js
@@ -48,7 +48,7 @@ class MSEController {
         };
 
         // Use ManagedMediaSource only if w3c MediaSource is not available (e.g. iOS Safari)
-        this._useManagedMediaSource = ('ManagedMediaSource' in self) && !('MediaSource' in self);
+        this._useManagedMediaSource = (typeof self.ManagedMediaSource === 'function') && !(typeof self.MediaSource === 'function');
 
         this._mediaSource = null;
         this._mediaSourceObjectURL = null;


### PR DESCRIPTION
### Problem
The current code uses the `in` operator to detect if `MediaSource` and `ManagedMediaSource` exist. This approach has a potential issue: if someone sets `window.MediaSource = undefined`, using the `in` operator would still return `true` because the property exists, even though its value is `undefined`.

### Solution
Change the detection method from using the `in` operator to `typeof ... === 'function'` checks to ensure:
1. More accurately verify if objects are available
2. Confirm objects are actual callable constructor functions
3. Avoid false positives when properties exist but have invalid values

### Changes
```diff
-        this._useManagedMediaSource = ('ManagedMediaSource' in self) && !('MediaSource' in self);
+        this._useManagedMediaSource = (typeof self.ManagedMediaSource === 'function') && !(typeof self.MediaSource === 'function');
```

### Context
This is particularly important when third-party players use patterns like:
```javascript
window.MediaSource = window.MediaSource || window.WebKitMediaSource
```
which could create problems with the previous detection method if one of the values is undefined.

### Testing
Verified this change works correctly in all supported browser environments and properly handles cases where MediaSource constructor is set to undefined.