### PR TITLE
有时dts顺序问题导致计算出的sampleDuration为负值，播放时时间缀为1193小时

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -128,11 +128,33 @@ class MP4Remuxer {
         this._videoSegmentInfoList.clear();
         this._audioSegmentInfoList.clear();
     }
+    correctionVideoDts(videoTrack){
+        let outOrderSamples=[];
+        let preDts = 0;
+        for(let i=0;i<videoTrack.samples.length;i++){
+            let dts =  videoTrack.samples[i].dts;
+            if(dts<=preDts){
+                outOrderSamples.push(videoTrack.samples[i]);
+            }else{
+                if(outOrderSamples.length>0){
+                    let duration = (dts-preDts)/(outOrderSamples.length+1)
+                    for(let j=0;j<outOrderSamples.length;j++){
+                        let oldDts = outOrderSamples[j].dts;
+                        outOrderSamples[j].dts = preDts+ (j+1)*duration;
+                        outOrderSamples[j].pts = outOrderSamples[j].pts+(oldDts-outOrderSamples[j].dts);
+                    }
+                }
+                outOrderSamples=[];
+                preDts = dts;
+            }
+        }
+    }
 
     remux(audioTrack, videoTrack) {
         if (!this._onMediaSegment) {
             throw new IllegalStateException('MP4Remuxer: onMediaSegment callback must be specificed!');
         }
+        this.correctionVideoDts(videoTrack);
         if (!this._dtsBaseInited) {
             this._calculateDtsBase(audioTrack, videoTrack);
         }
@@ -678,7 +700,9 @@ class MP4Remuxer {
                 syncPoint.fileposition = sample.fileposition;
                 info.appendSyncPoint(syncPoint);
             }
-
+            if(dts<0||sampleDuration<0){
+                debugger
+            }else
             mp4Samples.push({
                 dts: dts,
                 pts: pts,


### PR DESCRIPTION
<img width="556" height="265" alt="image" src="https://github.com/user-attachments/assets/939290e8-5428-4db8-96aa-0d43be7cb02c" />