### PR TITLE
fix: IOS 26 err

### DIFF
--- a/src/core/mse-controller.js
+++ b/src/core/mse-controller.js
@@ -48,7 +48,7 @@ class MSEController {
         };
 
         // Use ManagedMediaSource only if w3c MediaSource is not available (e.g. iOS Safari)
-        this._useManagedMediaSource = ('ManagedMediaSource' in self) && !('MediaSource' in self);
+        this._useManagedMediaSource = ('ManagedMediaSource' in self) && (!('MediaSource' in self) || !self.MediaSource);
 
         this._mediaSource = null;
         this._mediaSourceObjectURL = null;

--- a/src/player/player-engine-dedicated-thread.ts
+++ b/src/player/player-engine-dedicated-thread.ts
@@ -375,7 +375,7 @@ class PlayerEngineDedicatedThread implements PlayerEngine {
             case 'mse_init': {
                 const packet = message_packet as WorkerMessagePacketMSEInit;
                 // Use ManagedMediaSource only if w3c MediaSource is not available (e.g. iOS Safari)
-                const use_managed_media_source = ('ManagedMediaSource' in self) && !('MediaSource' in self);
+                const use_managed_media_source = ('ManagedMediaSource' in self) && (!('MediaSource' in self) || !self.MediaSource);
                 if (use_managed_media_source) {
                     // When using ManagedMediaSource, MediaSource will not open unless disableRemotePlayback is set to true
                     this._media_element['disableRemotePlayback'] = true;


### PR DESCRIPTION
In iOS 26, `'MediaSource' in self` is true, but `self.MediaSource` is undefined.