### PR TITLE
feat(demux): Add SEI_ARRIVED event

### DIFF
--- a/src/core/transmuxer.js
+++ b/src/core/transmuxer.js
@@ -66,6 +66,7 @@ class Transmuxer {
             ctl.on(TransmuxingEvents.SYNCHRONOUS_KLV_METADATA_ARRIVED, this._onSynchronousKLVMetadataArrived.bind(this));
             ctl.on(TransmuxingEvents.ASYNCHRONOUS_KLV_METADATA_ARRIVED, this._onAsynchronousKLVMetadataArrived.bind(this));
             ctl.on(TransmuxingEvents.SMPTE2038_METADATA_ARRIVED, this._onSMPTE2038MetadataArrived.bind(this));
+            ctl.on(TransmuxingEvents.SEI_ARRIVED, this._onSEIArrived.bind(this));
             ctl.on(TransmuxingEvents.SCTE35_METADATA_ARRIVED, this._onSCTE35MetadataArrived.bind(this));
             ctl.on(TransmuxingEvents.PES_PRIVATE_DATA_DESCRIPTOR, this._onPESPrivateDataDescriptor.bind(this));
             ctl.on(TransmuxingEvents.PES_PRIVATE_DATA_ARRIVED, this._onPESPrivateDataArrived.bind(this));
@@ -215,6 +216,12 @@ class Transmuxer {
         })
     }
 
+    _onSEIArrived (data) {
+        Promise.resolve().then(() => {
+            this._emitter.emit(TransmuxingEvents.SEI_ARRIVED, data);
+        })
+    }
+
     _onSCTE35MetadataArrived (data) {
         Promise.resolve().then(() => {
             this._emitter.emit(TransmuxingEvents.SCTE35_METADATA_ARRIVED, data);
@@ -295,6 +302,7 @@ class Transmuxer {
             case TransmuxingEvents.ASYNCHRONOUS_KLV_METADATA_ARRIVED:
             case TransmuxingEvents.SMPTE2038_METADATA_ARRIVED:
             case TransmuxingEvents.SCTE35_METADATA_ARRIVED:
+            case TransmuxingEvents.SEI_ARRIVED:
             case TransmuxingEvents.PES_PRIVATE_DATA_DESCRIPTOR:
             case TransmuxingEvents.PES_PRIVATE_DATA_ARRIVED:
             case TransmuxingEvents.STATISTICS_INFO:

--- a/src/core/transmuxing-controller.js
+++ b/src/core/transmuxing-controller.js
@@ -303,6 +303,7 @@ class TransmuxingController {
         this._demuxer.onMediaInfo = this._onMediaInfo.bind(this);
         this._demuxer.onMetaDataArrived = this._onMetaDataArrived.bind(this);
         this._demuxer.onScriptDataArrived = this._onScriptDataArrived.bind(this);
+        this._demuxer.onSeiArrived = this._onSEI.bind(this);
 
         this._remuxer.bindDataSource(this._demuxer
                         .bindDataSource(this._ioctl
@@ -327,6 +328,7 @@ class TransmuxingController {
         demuxer.onSynchronousKLVMetadata = this._onSynchronousKLVMetadata.bind(this);
         demuxer.onAsynchronousKLVMetadata = this._onAsynchronousKLVMetadata.bind(this);
         demuxer.onSMPTE2038Metadata = this._onSMPTE2038Metadata.bind(this);
+        demuxer.onSEI = this._onSEI.bind(this);
         demuxer.onSCTE35Metadata = this._onSCTE35Metadata.bind(this);
         demuxer.onPESPrivateDataDescriptor = this._onPESPrivateDataDescriptor.bind(this);
         demuxer.onPESPrivateData = this._onPESPrivateData.bind(this);
@@ -438,6 +440,17 @@ class TransmuxingController {
         }
 
         this._emitter.emit(TransmuxingEvents.SMPTE2038_METADATA_ARRIVED, smpte2038_metadata);
+    }
+
+    _onSEI(sei_data) {
+        let timestamp_base = this._remuxer.getTimestampBase();
+        if (timestamp_base == undefined) { return; }
+
+        if (sei_data.pts != undefined) {
+            sei_data.pts -= timestamp_base;
+        }
+
+        this._emitter.emit(TransmuxingEvents.SEI_ARRIVED, sei_data);
     }
 
     _onSCTE35Metadata(scte35) {

--- a/src/core/transmuxing-events.ts
+++ b/src/core/transmuxing-events.ts
@@ -31,6 +31,7 @@ enum TransmuxingEvents {
     SYNCHRONOUS_KLV_METADATA_ARRIVED = 'synchronous_klv_metadata_arrived',
     ASYNCHRONOUS_KLV_METADATA_ARRIVED = 'asynchronous_klv_metadata_arrived',
     SMPTE2038_METADATA_ARRIVED = 'smpte2038_metadata_arrived',
+    SEI_ARRIVED = 'sei_arrived',
     SCTE35_METADATA_ARRIVED = 'scte35_metadata_arrived',
     PES_PRIVATE_DATA_DESCRIPTOR = 'pes_private_data_descriptor',
     PES_PRIVATE_DATA_ARRIVED = 'pes_private_data_arrived',

--- a/src/core/transmuxing-worker.js
+++ b/src/core/transmuxing-worker.js
@@ -61,6 +61,7 @@ let TransmuxingWorker = function (self) {
                 controller.on(TransmuxingEvents.SYNCHRONOUS_KLV_METADATA_ARRIVED, onSynchronousKLVMetadataArrived.bind(this));
                 controller.on(TransmuxingEvents.ASYNCHRONOUS_KLV_METADATA_ARRIVED, onAsynchronousKLVMetadataArrived.bind(this));
                 controller.on(TransmuxingEvents.SMPTE2038_METADATA_ARRIVED, onSMPTE2038MetadataArrived.bind(this));
+                controller.on(TransmuxingEvents.SEI_ARRIVED, onSEIArrived.bind(this));
                 controller.on(TransmuxingEvents.SCTE35_METADATA_ARRIVED, onSCTE35MetadataArrived.bind(this));
                 controller.on(TransmuxingEvents.PES_PRIVATE_DATA_DESCRIPTOR, onPESPrivateDataDescriptor.bind(this));
                 controller.on(TransmuxingEvents.PES_PRIVATE_DATA_ARRIVED, onPESPrivateDataArrived.bind(this));
@@ -198,6 +199,14 @@ let TransmuxingWorker = function (self) {
     function onSMPTE2038MetadataArrived (data) {
         let obj = {
             msg: TransmuxingEvents.SMPTE2038_METADATA_ARRIVED,
+            data: data
+        };
+        self.postMessage(obj);
+    }
+
+    function onSEIArrived (data) {
+        let obj = {
+            msg: TransmuxingEvents.SEI_ARRIVED,
             data: data
         };
         self.postMessage(obj);

--- a/src/demux/base-demuxer.ts
+++ b/src/demux/base-demuxer.ts
@@ -4,6 +4,7 @@ import { SMPTE2038Data } from './smpte2038';
 import { SCTE35Data } from './scte35';
 import { KLVData } from './klv';
 import { PGSData } from './pgs-data';
+import { SEIData } from './sei';
 
 type OnErrorCallback = (type: string, info: string) => void;
 type OnMediaInfoCallback = (mediaInfo: MediaInfo) => void;
@@ -15,6 +16,7 @@ type onPGSSubitleDataCallback = (pgs_data: PGSData) => void;
 type OnSynchronousKLVMetadataCallback = (synchronous_klv_data: KLVData) => void;
 type OnAsynchronousKLVMetadataCallback = (asynchronous_klv_data: PESPrivateData) => void;
 type OnSMPTE2038MetadataCallback = (smpte2038_data: SMPTE2038Data) => void;
+type OnSEICallback = (sei_data: SEIData) => void;
 type OnSCTE35MetadataCallback = (scte35_data: SCTE35Data) => void;
 type OnPESPrivateDataCallback = (private_data: PESPrivateData) => void;
 type OnPESPrivateDataDescriptorCallback = (private_data_descriptor: PESPrivateDataDescriptor) => void;
@@ -31,6 +33,7 @@ export default abstract class BaseDemuxer {
     public onSynchronousKLVMetadata: OnSynchronousKLVMetadataCallback
     public onAsynchronousKLVMetadata: OnAsynchronousKLVMetadataCallback;
     public onSMPTE2038Metadata: OnSMPTE2038MetadataCallback;
+    public onSEI: OnSEICallback;
     public onSCTE35Metadata: OnSCTE35MetadataCallback;
     public onPESPrivateData: OnPESPrivateDataCallback;
     public onPESPrivateDataDescriptor: OnPESPrivateDataDescriptorCallback;
@@ -48,6 +51,7 @@ export default abstract class BaseDemuxer {
         this.onSynchronousKLVMetadata = null;
         this.onAsynchronousKLVMetadata = null;
         this.onSMPTE2038Metadata = null;
+        this.onSEI = null;
         this.onSCTE35Metadata = null;
         this.onPESPrivateData = null;
         this.onPESPrivateDataDescriptor = null;

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -470,8 +470,7 @@ class FLVDemuxer {
     }
 
     _parseSEIPayload(data, pts, codec) {
-        let timestamp = pts != undefined ? Math.floor(pts / this._timescale) : undefined;
-        let sei_data = parseSEI(data, timestamp, codec);
+        let sei_data = parseSEI(data, pts, codec);
 
         if (sei_data && typeof this._onSeiArrived === 'function') {
             this._onSeiArrived(sei_data);
@@ -1694,7 +1693,7 @@ class FLVDemuxer {
             length += data.byteLength;
 
             if (unitType === 6) {  // SEI
-                this._parseSEIPayload(data, dts + cts, 'h264');
+                this._parseSEIPayload(data.subarray(lengthSize), dts + cts, 'h264');
             }
 
             offset += lengthSize + naluSize;
@@ -1756,7 +1755,7 @@ class FLVDemuxer {
             length += data.byteLength;
 
             if (unitType === 39 || unitType === 40) {  // Prefix / Suffix SEI
-                this._parseSEIPayload(data, dts + cts, 'h265');
+                this._parseSEIPayload(data.subarray(lengthSize), dts + cts, 'h265');
             }
 
             offset += lengthSize + naluSize;

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -26,6 +26,7 @@ import H265Parser from './h265-parser.js';
 import buffersAreEqual from '../utils/typedarray-equality.ts';
 import AV1OBUParser from './av1-parser.ts';
 import ExpGolomb from './exp-golomb.js';
+import { parseSEI } from './sei';
 
 function Swap16(src) {
     return (((src >>> 8) & 0xFF) |
@@ -60,6 +61,7 @@ class FLVDemuxer {
         this._onScriptDataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
+        this._onSeiArrived = null;
 
         this._dataOffset = probeData.dataOffset;
         this._firstParse = true;
@@ -132,6 +134,7 @@ class FLVDemuxer {
         this._onScriptDataArrived = null;
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
+        this._onSeiArrived = null;
     }
 
     static probe(buffer) {
@@ -201,6 +204,14 @@ class FLVDemuxer {
 
     set onScriptDataArrived(callback) {
         this._onScriptDataArrived = callback;
+    }
+
+    get onSeiArrived() {
+        return this._onSeiArrived
+    }
+
+    set onSeiArrived(callback) {
+        this._onSeiArrived = callback;
     }
 
     // prototype: function(type: number, info: string): void
@@ -455,6 +466,15 @@ class FLVDemuxer {
             if (this._onScriptDataArrived) {
                 this._onScriptDataArrived(Object.assign({}, scriptData));
             }
+        }
+    }
+
+    _parseSEIPayload(data, pts, codec) {
+        let timestamp = pts != undefined ? Math.floor(pts / this._timescale) : undefined;
+        let sei_data = parseSEI(data, timestamp, codec);
+
+        if (sei_data && typeof this._onSeiArrived === 'function') {
+            this._onSeiArrived(sei_data);
         }
     }
 
@@ -1673,6 +1693,10 @@ class FLVDemuxer {
             units.push(unit);
             length += data.byteLength;
 
+            if (unitType === 6) {  // SEI
+                this._parseSEIPayload(data, dts + cts, 'h264');
+            }
+
             offset += lengthSize + naluSize;
         }
 
@@ -1730,6 +1754,10 @@ class FLVDemuxer {
             let unit = {type: unitType, data: data};
             units.push(unit);
             length += data.byteLength;
+
+            if (unitType === 39 || unitType === 40) {  // Prefix / Suffix SEI
+                this._parseSEIPayload(data, dts + cts, 'h265');
+            }
 
             offset += lengthSize + naluSize;
         }

--- a/src/demux/h265.ts
+++ b/src/demux/h265.ts
@@ -8,6 +8,8 @@ export enum H265NaluType {
     kSliceSPS = 33,
     kSlicePPS = 34,
     kSliceAUD = 35,
+    kSliceSEI = 39,
+    kSliceSEISuffix = 40,
 }
 
 export class H265NaluPayload {

--- a/src/demux/sei.ts
+++ b/src/demux/sei.ts
@@ -1,0 +1,99 @@
+
+export class SEIData {
+    type: number;
+    size: number;
+    uuid: Uint8Array;
+    user_data: Uint8Array;
+    pts?: number;
+}
+
+function ebsp2rbsp(uint8array: Uint8Array): Uint8Array {
+    let src = uint8array;
+    let src_length = src.byteLength;
+    let dst = new Uint8Array(src_length);
+    let dst_idx = 0;
+
+    for (let i = 0; i < src_length; i++) {
+        if (i >= 2) {
+            // Unescape: Skip 0x03 after 00 00
+            if (src[i] === 0x03 && src[i - 1] === 0x00 && src[i - 2] === 0x00) {
+                continue;
+            }
+        }
+        dst[dst_idx] = src[i];
+        dst_idx++;
+    }
+
+    return new Uint8Array(dst.buffer, 0, dst_idx);
+}
+
+export function parseSEI(data: Uint8Array, pts?: number, codec?: 'h264' | 'h265'): SEIData | null {
+    if (!data || data.byteLength < 2) {
+        return null;
+    }
+
+    // Determine NALU header size based on codec
+    let naluHeaderSize = 1;  // Default for H.264
+    if (codec === 'h265') {
+        naluHeaderSize = 2;
+    }
+
+    // Convert EBSP to RBSP (skip NALU header)
+    let rbsp_data = ebsp2rbsp(data.subarray(naluHeaderSize));
+    let offset = 0;
+
+    // Check for trailing bits (0x80)
+    if (offset === rbsp_data.byteLength - 1 && rbsp_data[offset] === 0x80) {
+        return null;
+    }
+
+    // Parse payload type (can be multiple bytes for extended types)
+    let payloadType = 0;
+    while (offset < rbsp_data.byteLength && rbsp_data[offset] === 0xFF) {
+        payloadType += 255;
+        offset++;
+    }
+    if (offset >= rbsp_data.byteLength) {
+        return null;
+    }
+    payloadType += rbsp_data[offset++];
+
+    // Parse payload size (can be multiple bytes for extended sizes)
+    let payloadSize = 0;
+    while (offset < rbsp_data.byteLength && rbsp_data[offset] === 0xFF) {
+        payloadSize += 255;
+        offset++;
+    }
+    if (offset >= rbsp_data.byteLength) {
+        return null;
+    }
+    payloadSize += rbsp_data[offset++];
+
+    // Check if we have enough data
+    if (offset + payloadSize > rbsp_data.byteLength) {
+        return null;
+    }
+
+    let sei_data = new SEIData();
+    sei_data.type = payloadType;
+    sei_data.size = payloadSize;
+
+    // Extract payload
+    let payload = rbsp_data.subarray(offset, offset + payloadSize);
+
+    // SEI payload type 5 is user_data_unregistered (with UUID)
+    // This is the same for both H.264 and H.265
+    if (payloadType === 5 && payloadSize >= 16) {
+        // First 16 bytes are UUID
+        sei_data.uuid = payload.subarray(0, 16);
+        sei_data.user_data = payload.subarray(16);
+    } else {
+        // ignore
+    }
+
+    if (pts !== undefined) {
+        sei_data.pts = pts;
+    }
+
+    return sei_data;
+}

--- a/src/demux/ts-demuxer.ts
+++ b/src/demux/ts-demuxer.ts
@@ -27,6 +27,7 @@ import SPSParser from './sps-parser';
 import { AACADTSParser, AACFrame, AACLOASParser, AudioSpecificConfig, LOASAACFrame } from './aac';
 import { MPEG4AudioObjectTypes, MPEG4SamplingFrequencyIndex } from './mpeg4-audio';
 import { PESPrivateData, PESPrivateDataDescriptor } from './pes-private-data';
+import { parseSEI } from './sei';
 import { readSCTE35, SCTE35Data } from './scte35';
 import { H265AnnexBParser, H265NaluHVC1, H265NaluPayload, H265NaluType, HEVCDecoderConfigurationRecord } from './h265';
 import H265Parser from './h265-parser';
@@ -1047,6 +1048,8 @@ class TSDemuxer extends BaseDemuxer {
             } else if (nalu_avc1.type === H264NaluType.kSliceNonIDR && random_access_indicator === 1) {
                 // For open-gop stream, use random_access_indicator to identify keyframe
                 keyframe = true;
+            } else if (nalu_avc1.type === H264NaluType.kSliceSEI) {
+                this.parseSEIPayload(nalu_payload.data, pts, 'h264');
             }
 
             // Push samples to remuxer only if initialization metadata has been dispatched
@@ -1127,6 +1130,8 @@ class TSDemuxer extends BaseDemuxer {
                 }
             } else if (nalu_hvc1.type === H265NaluType.kSliceIDR_W_RADL || nalu_hvc1.type === H265NaluType.kSliceIDR_N_LP || nalu_hvc1.type === H265NaluType.kSliceCRA_NUT) {
                 keyframe = true;
+            } else if (nalu_hvc1.type === H265NaluType.kSliceSEI || nalu_hvc1.type === H265NaluType.kSliceSEISuffix) {
+                this.parseSEIPayload(nalu_payload.data, pts, 'h265');
             }
 
             // Push samples to remuxer only if initialization metadata has been dispatched
@@ -2108,6 +2113,15 @@ class TSDemuxer extends BaseDemuxer {
         smpte2038_data.ancillaries = smpte2038parse(data);
         if (this.onSMPTE2038Metadata) {
             this.onSMPTE2038Metadata(smpte2038_data);
+        }
+    }
+
+    private parseSEIPayload(data: Uint8Array, pts: number, codec: 'h264' | 'h265') {
+        let timestamp = pts != undefined ? Math.floor(pts / this.timescale_) : undefined;
+        let sei_data = parseSEI(data, timestamp, codec);
+
+        if (sei_data && this.onSEI) {
+            this.onSEI(sei_data);
         }
     }
 

--- a/src/player/player-engine-main-thread.ts
+++ b/src/player/player-engine-main-thread.ts
@@ -243,6 +243,9 @@ class PlayerEngineMainThread implements PlayerEngine {
         this._transmuxer.on(TransmuxingEvents.SMPTE2038_METADATA_ARRIVED, (smpte2038_metadata: any) => {
             this._emitter.emit(PlayerEvents.SMPTE2038_METADATA_ARRIVED, smpte2038_metadata);
         });
+        this._transmuxer.on(TransmuxingEvents.SEI_ARRIVED, (sei_data: any) => {
+            this._emitter.emit(PlayerEvents.SEI_ARRIVED, sei_data);
+        });
         this._transmuxer.on(TransmuxingEvents.SCTE35_METADATA_ARRIVED, (scte35_metadata: any) => {
             this._emitter.emit(PlayerEvents.SCTE35_METADATA_ARRIVED, scte35_metadata);
         });

--- a/src/player/player-engine-worker-msg-def.ts
+++ b/src/player/player-engine-worker-msg-def.ts
@@ -66,6 +66,7 @@ export type WorkerMessagePacketPlayerEventExtraData = WorkerMessagePacketPlayerE
         | PlayerEvents.SYNCHRONOUS_KLV_METADATA_ARRIVED
         | PlayerEvents.ASYNCHRONOUS_KLV_METADATA_ARRIVED
         | PlayerEvents.SMPTE2038_METADATA_ARRIVED
+        | PlayerEvents.SEI_ARRIVED
         | PlayerEvents.SCTE35_METADATA_ARRIVED
         | PlayerEvents.PES_PRIVATE_DATA_DESCRIPTOR
         | PlayerEvents.PES_PRIVATE_DATA_ARRIVED,

--- a/src/player/player-engine-worker.ts
+++ b/src/player/player-engine-worker.ts
@@ -264,6 +264,9 @@ const PlayerEngineWorker = (self: DedicatedWorkerGlobalScope) => {
         transmuxer.on(TransmuxingEvents.SMPTE2038_METADATA_ARRIVED, (smpte2038_metadata: any) => {
             emitPlayerEventsExtraData(PlayerEvents.SMPTE2038_METADATA_ARRIVED, smpte2038_metadata);
         });
+        transmuxer.on(TransmuxingEvents.SEI_ARRIVED, (sei_data: any) => {
+            emitPlayerEventsExtraData(PlayerEvents.SEI_ARRIVED, sei_data);
+        });
         transmuxer.on(TransmuxingEvents.SCTE35_METADATA_ARRIVED, (scte35_metadata: any) => {
             emitPlayerEventsExtraData(PlayerEvents.SCTE35_METADATA_ARRIVED, scte35_metadata);
         });

--- a/src/player/player-events.ts
+++ b/src/player/player-events.ts
@@ -28,6 +28,7 @@ enum PlayerEvents {
     SYNCHRONOUS_KLV_METADATA_ARRIVED = 'synchronous_klv_metadata_arrived',
     ASYNCHRONOUS_KLV_METADATA_ARRIVED = 'asynchronous_klv_metadata_arrived',
     SMPTE2038_METADATA_ARRIVED = 'smpte2038_metadata_arrived',
+    SEI_ARRIVED = 'sei_arrived',
     SCTE35_METADATA_ARRIVED = 'scte35_metadata_arrived',
     PES_PRIVATE_DATA_DESCRIPTOR = 'pes_private_data_descriptor',
     PES_PRIVATE_DATA_ARRIVED = 'pes_private_data_arrived',


### PR DESCRIPTION
At present, a wide range of scenarios rely on SEI to convey custom metadata—for instance, DJI drones use SEI to deliver AI bounding-box detections, security platforms transmit OSD via SEI, and live-streaming services embed co-hosting (PK) information the same way. 

Once the player receives this data, it can overlay the SEI payload onto the video layer during rendering. Without such a mechanism, the server must perform a full decode–overlay–re-encode cycle, which is exceptionally resource-intensive.

This update introduces SEI event notifications. Going forward, I will add a parsing library—akin to aribb24.js—to be used in conjunction with this update.

At the moment, everyone is effectively building their own bespoke solutions; I hope this can serve as an opportunity to help drive a common standard. Thank you.