### PR TITLE
remux/mp4-remuxer: Fix an issue where disabling silent AAC insertion for Safari caused the audio timeline to accumulate and shorten, resulting in playback getting stuck on Safari 26.5 and later (Close #2)

### DIFF
--- a/src/remux/mp4-remuxer.js
+++ b/src/remux/mp4-remuxer.js
@@ -380,7 +380,7 @@ class MP4Remuxer {
                     Log.w(this.TAG, `Dropping 1 audio frame (originalDts: ${originalDts} ms ,curRefDts: ${curRefDts} ms)  due to dtsCorrection: ${dtsCorrection} ms overlap.`);
                     continue;
                 }
-                else if (dtsCorrection >= maxAudioFramesDrift * refSampleDuration && this._fillAudioTimestampGap && !Browser.safari) {
+                else if (dtsCorrection >= maxAudioFramesDrift * refSampleDuration && this._fillAudioTimestampGap) {
                     // Silent frame generation, if large timestamp gap detected && config.fixAudioTimestampGap
                     needFillSilentFrames = true;
                     // We need to insert silent frames to fill timestamp gap


### PR DESCRIPTION
@xqq タイトルの通りです！
https://github.com/tsukumijima/mpegts.js/issues/2 で報告いただいた、Safari 26.5 以降で MSE 再生が不安定になる問題、および音ズレが発生する問題（26.5 以前も発生していた・・・？）の修正になります。
なぜこれで直るのかまではよくわかっていませんが、2017年の MSE 登場初期の Safari のクセを吸収するための修正が今は逆効果になっている、と考えるのが整合するでしょうか。