### PR TITLE
feat: add G.711 PCMA audio support for FLV streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ mpegts.js works by transmuxing MPEG2-TS stream into ISO BMFF (Fragmented MP4) se
 [Media Source Extensions]: https://w3c.github.io/media-source/
 
 ## News
+- **v1.8.2** (@brid9e fork)
+
+    Added support for **G.711 PCMA** (FLV audio codec index 7) commonly used in surveillance cameras and IP cameras. PCMA frames are decoded via the Web Audio API and played in parallel with the MSE video pipeline, since G.711 is not supported by Media Source Extensions.
+
 - **v1.8.0**
 
     Support working on **iOS Safari** with iOS 17.1+ through Apple's [ManagedMediaSource API](https://github.com/w3c/media-source/issues/320)
@@ -51,6 +55,7 @@ mpegts.js works by transmuxing MPEG2-TS stream into ISO BMFF (Fragmented MP4) se
 ## Features
 - Playback for MPEG2-TS stream with H.264/H.265 + AAC codec transported in http(s) or WebSocket
 - Playback for FLV stream with H.264/H.265 + AAC codec transported in http(s) or WebSocket
+- **G.711 PCMA audio support for FLV streams** (codec index 7), decoded via Web Audio API — common in surveillance/IP cameras
 - Extremely low latency of less than 1 second in the best case
 - Playback for `.m2ts` file like BDAV/BDMV with 192 bytes TS packet, or 204 bytes TS packet
 - Support handling dynamic codec parameters change (e.g. video resolution change)

--- a/README_zh.md
+++ b/README_zh.md
@@ -12,6 +12,10 @@ mpegts.js 通过在 JavaScript 中渐进化解析 MPEG2-TS 流并实时转封装
 [Media Source Extensions]: https://w3c.github.io/media-source/
 
 ## News
+- **v1.8.2**（@brid9e fork）
+
+    新增 **G.711 PCMA** 音频支持（FLV 音频编码索引 7），常见于监控摄像头和 IP 摄像机。由于 MSE 不支持 G.711，PCMA 帧通过 Web Audio API 解码，与 MSE 视频管线并行播放。
+
 - **v1.8.0**
 
     支持在 **iOS Safari**（iOS 17.1+）上运行，使用 Apple [ManagedMediaSource API](https://github.com/w3c/media-source/issues/320)
@@ -50,6 +54,7 @@ mpegts.js 通过在 JavaScript 中渐进化解析 MPEG2-TS 流并实时转封装
 ## Features
 - 回放 http(s) 或 WebSocket 上承载的 H.264/H.265 + AAC 编码的 MPEG2-TS 流
 - 回放 http(s) 或 WebSocket 上承载的 H.264/H.265 + AAC 编码的 FLV 流
+- **支持 FLV 流中的 G.711 PCMA 音频**（编码索引 7），通过 Web Audio API 解码，适用于监控/IP 摄像机场景
 - 超低延迟，最佳情况延迟可低达 1 秒以内
 - 回放 TS packet 为 192 字节的 `.m2ts` 文件（BDAV/BDMV）或 204 字节的 TS 流
 - 支持动态编码参数切换，如视频分辨率动态变化

--- a/d.ts/src/core/transmuxer.d.ts
+++ b/d.ts/src/core/transmuxer.d.ts
@@ -38,6 +38,7 @@ declare class Transmuxer {
     _onIOError(type: any, info: any): void;
     _onDemuxError(type: any, info: any): void;
     _onRecommendSeekpoint(milliseconds: any): void;
+    _onG711AudioData(pcmaData: any, dts: any, channelCount: any): void;
     _onLoggingConfigChanged(config: any): void;
     _onWorkerMessage(e: any): void;
 }

--- a/d.ts/src/core/transmuxing-events.d.ts
+++ b/d.ts/src/core/transmuxing-events.d.ts
@@ -18,6 +18,7 @@ declare enum TransmuxingEvents {
     PES_PRIVATE_DATA_DESCRIPTOR = "pes_private_data_descriptor",
     PES_PRIVATE_DATA_ARRIVED = "pes_private_data_arrived",
     STATISTICS_INFO = "statistics_info",
-    RECOMMEND_SEEKPOINT = "recommend_seekpoint"
+    RECOMMEND_SEEKPOINT = "recommend_seekpoint",
+    G711_AUDIO_DATA = "g711_audio_data"
 }
 export default TransmuxingEvents;

--- a/d.ts/src/demux/flv-demuxer.d.ts
+++ b/d.ts/src/demux/flv-demuxer.d.ts
@@ -15,6 +15,7 @@ declare class FLVDemuxer {
     _onTrackMetadata: any;
     _onDataAvailable: any;
     _onSeiArrived: any;
+    _onG711AudioData: any;
     _dataOffset: any;
     _firstParse: boolean;
     _dispatch: boolean;
@@ -74,6 +75,8 @@ declare class FLVDemuxer {
     get onScriptDataArrived(): any;
     set onSeiArrived(callback: any);
     get onSeiArrived(): any;
+    set onG711AudioData(callback: any);
+    get onG711AudioData(): any;
     set onError(callback: any);
     get onError(): any;
     set onDataAvailable(callback: any);

--- a/d.ts/src/player/player-engine-main-thread.d.ts
+++ b/d.ts/src/player/player-engine-main-thread.d.ts
@@ -19,6 +19,9 @@ declare class PlayerEngineMainThread implements PlayerEngine {
     private _loaded_metadata_received;
     private _media_info?;
     private _statistics_info?;
+    private _g711_audio_ctx?;
+    private _g711_gain_node?;
+    private _g711_next_play_time;
     private e?;
     constructor(mediaDataSource: any, config: any);
     destroy(): void;
@@ -45,5 +48,7 @@ declare class PlayerEngineMainThread implements PlayerEngine {
     private _onRequestPauseTransmuxer;
     private _onRequestResumeTransmuxer;
     private _fillStatisticsInfo;
+    private static readonly _PCMA_TABLE;
+    private _onG711AudioData;
 }
 export default PlayerEngineMainThread;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./d.ts/mpegts.d.ts",
   "repository": {
     "type": "git",
-    "url": "https://github.com/xqq/mpegts.js"
+    "url": "https://github.com/Brid9e/mpegts.js"
   },
   "keywords": [
     "html5",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "mpegts.js",
+  "name": "@brid9e/mpegts.js",
   "version": "1.8.2",
   "description": "HTML5 MPEG2-TS Stream Player",
   "main": "./dist/mpegts.js",
@@ -40,5 +40,9 @@
     "webpack-dev-server": "^6.0.0"
   },
   "author": "zheng qian <xqq@xqq.im>",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brid9e/mpegts.js",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "HTML5 MPEG2-TS Stream Player",
   "main": "./dist/mpegts.js",
   "types": "./d.ts/mpegts.d.ts",

--- a/src/core/transmuxer.js
+++ b/src/core/transmuxer.js
@@ -72,6 +72,7 @@ class Transmuxer {
             ctl.on(TransmuxingEvents.PES_PRIVATE_DATA_ARRIVED, this._onPESPrivateDataArrived.bind(this));
             ctl.on(TransmuxingEvents.STATISTICS_INFO, this._onStatisticsInfo.bind(this));
             ctl.on(TransmuxingEvents.RECOMMEND_SEEKPOINT, this._onRecommendSeekpoint.bind(this));
+            ctl.on(TransmuxingEvents.G711_AUDIO_DATA, this._onG711AudioData.bind(this));
         }
     }
 
@@ -264,6 +265,12 @@ class Transmuxer {
         });
     }
 
+    _onG711AudioData(pcmaData, dts, channelCount) {
+        Promise.resolve().then(() => {
+            this._emitter.emit(TransmuxingEvents.G711_AUDIO_DATA, pcmaData, dts, channelCount);
+        });
+    }
+
     _onLoggingConfigChanged(config) {
         if (this._worker) {
             this._worker.postMessage({cmd: 'logging_config', param: config});
@@ -314,6 +321,9 @@ class Transmuxer {
                 break;
             case TransmuxingEvents.RECOMMEND_SEEKPOINT:
                 this._emitter.emit(message.msg, data);
+                break;
+            case TransmuxingEvents.G711_AUDIO_DATA:
+                this._emitter.emit(message.msg, data.pcmaData, data.dts, data.channelCount);
                 break;
             case 'logcat_callback':
                 Log.emitter.emit('log', data.type, data.logcat);

--- a/src/core/transmuxing-controller.js
+++ b/src/core/transmuxing-controller.js
@@ -305,6 +305,9 @@ class TransmuxingController {
         this._demuxer.onMetaDataArrived = this._onMetaDataArrived.bind(this);
         this._demuxer.onScriptDataArrived = this._onScriptDataArrived.bind(this);
         this._demuxer.onSeiArrived = this._onSEI.bind(this);
+        this._demuxer.onG711AudioData = (pcmaData, dts, channelCount) => {
+            this._emitter.emit(TransmuxingEvents.G711_AUDIO_DATA, pcmaData, dts, channelCount);
+        };
 
         this._remuxer.bindDataSource(this._demuxer
                         .bindDataSource(this._ioctl

--- a/src/core/transmuxing-events.ts
+++ b/src/core/transmuxing-events.ts
@@ -36,7 +36,8 @@ enum TransmuxingEvents {
     PES_PRIVATE_DATA_DESCRIPTOR = 'pes_private_data_descriptor',
     PES_PRIVATE_DATA_ARRIVED = 'pes_private_data_arrived',
     STATISTICS_INFO = 'statistics_info',
-    RECOMMEND_SEEKPOINT = 'recommend_seekpoint'
+    RECOMMEND_SEEKPOINT = 'recommend_seekpoint',
+    G711_AUDIO_DATA = 'g711_audio_data'
 };
 
 export default TransmuxingEvents;

--- a/src/demux/flv-demuxer.js
+++ b/src/demux/flv-demuxer.js
@@ -62,6 +62,7 @@ class FLVDemuxer {
         this._onTrackMetadata = null;
         this._onDataAvailable = null;
         this._onSeiArrived = null;
+        this._onG711AudioData = null;
 
         this._dataOffset = probeData.dataOffset;
         this._firstParse = true;
@@ -212,6 +213,14 @@ class FLVDemuxer {
 
     set onSeiArrived(callback) {
         this._onSeiArrived = callback;
+    }
+
+    get onG711AudioData() {
+        return this._onG711AudioData;
+    }
+
+    set onG711AudioData(callback) {
+        this._onG711AudioData = callback;
     }
 
     // prototype: function(type: number, info: string): void
@@ -535,7 +544,7 @@ class FLVDemuxer {
         }
         // Legacy FLV
 
-        if (soundFormat !== 2 && soundFormat !== 3 && soundFormat !== 10) {  // PCM or MP3 or AAC
+        if (soundFormat !== 2 && soundFormat !== 3 && soundFormat !== 7 && soundFormat !== 10) {  // PCM or MP3 or G711 PCMA or AAC
             this._onError(DemuxErrors.CODEC_UNSUPPORTED, 'Flv: Unsupported audio codec idx: ' + soundFormat);
             return;
         }
@@ -707,6 +716,30 @@ class FLVDemuxer {
             let pcmSample = {unit: data, length: data.byteLength, dts: dts, pts: dts};
             track.samples.push(pcmSample);
             track.length += data.length;
+        } else if (soundFormat === 7) {  // G.711 PCMA — bypass MSE, decode via Web Audio API
+            if (!meta.codec) {
+                meta.audioSampleRate = 8000;  // G.711 is always 8 kHz
+                meta.channelCount = (soundType === 0 ? 1 : 2);
+                meta.codec = 'pcma';
+                meta.originalCodec = 'pcma';
+
+                // Don't dispatch via _onTrackMetadata — G.711 is not remuxed into MP4
+                this._audioInitialMetadataDispatched = true;
+
+                let mi = this._mediaInfo;
+                mi.audioCodec = 'pcma';
+                mi.audioSampleRate = 8000;
+                mi.audioChannelCount = meta.channelCount;
+                if (mi.isComplete()) {
+                    this._onMediaInfo(mi);
+                }
+            }
+
+            if (this._onG711AudioData) {
+                let pcmaData = new Uint8Array(arrayBuffer, dataOffset + 1, dataSize - 1);
+                let dts = this._timestampBase + tagTimestamp;
+                this._onG711AudioData(pcmaData, dts, meta.channelCount);
+            }
         }
     }
 

--- a/src/player/player-engine-main-thread.ts
+++ b/src/player/player-engine-main-thread.ts
@@ -62,6 +62,10 @@ class PlayerEngineMainThread implements PlayerEngine {
     private _media_info?: MediaInfo = null;
     private _statistics_info?: any = null;
 
+    private _g711_audio_ctx?: AudioContext = null;
+    private _g711_gain_node?: GainNode = null;
+    private _g711_next_play_time: number = 0;
+
     private e?: any = null;
 
     public constructor(mediaDataSource: any, config: any) {
@@ -255,6 +259,9 @@ class PlayerEngineMainThread implements PlayerEngine {
         this._transmuxer.on(TransmuxingEvents.PES_PRIVATE_DATA_ARRIVED, (private_data: any) => {
             this._emitter.emit(PlayerEvents.PES_PRIVATE_DATA_ARRIVED, private_data);
         });
+        this._transmuxer.on(TransmuxingEvents.G711_AUDIO_DATA, (pcmaData: Uint8Array, dts: number, channelCount: number) => {
+            this._onG711AudioData(pcmaData, dts, channelCount);
+        });
 
         this._seeking_handler = new SeekingHandler(
             this._config,
@@ -321,6 +328,13 @@ class PlayerEngineMainThread implements PlayerEngine {
         this._transmuxer?.close();
         this._transmuxer?.destroy();
         this._transmuxer = null;
+
+        if (this._g711_audio_ctx) {
+            this._g711_audio_ctx.close();
+            this._g711_audio_ctx = null;
+            this._g711_gain_node = null;
+        }
+        this._g711_next_play_time = 0;
     }
 
     public play(): Promise<void> {
@@ -447,6 +461,66 @@ class PlayerEngineMainThread implements PlayerEngine {
         }
 
         return stat_info;
+    }
+
+    // G.711 PCMA lookup table: 256 entries mapping each PCMA byte to a signed 16-bit PCM value.
+    // PCMA encoding: sign bit (bit 7), 3-bit exponent (bits 6-4), 4-bit mantissa (bits 3-0).
+    private static readonly _PCMA_TABLE: Int16Array = (() => {
+        const table = new Int16Array(256);
+        for (let i = 0; i < 256; i++) {
+            let a = i ^ 0x55;  // XOR with 0x55 as per G.711 spec
+            const sign = a & 0x80;
+            a &= 0x7f;
+            let linear: number;
+            if (a >= 16) {
+                const exp = (a >> 4) & 0x07;
+                const mantissa = a & 0x0f;
+                linear = ((mantissa << 1) | 1) << (exp + 2);
+            } else {
+                linear = (a << 1) | 1;
+            }
+            table[i] = sign ? -linear : linear;
+        }
+        return table;
+    })();
+
+    private _onG711AudioData(pcmaData: Uint8Array, dts: number, channelCount: number): void {
+        if (!this._g711_audio_ctx) {
+            this._g711_audio_ctx = new AudioContext({ sampleRate: 8000 });
+            this._g711_gain_node = this._g711_audio_ctx.createGain();
+            this._g711_gain_node.connect(this._g711_audio_ctx.destination);
+            this._g711_next_play_time = this._g711_audio_ctx.currentTime;
+        }
+
+        const ctx = this._g711_audio_ctx;
+        const gain = this._g711_gain_node;
+
+        // Sync gain from <video> element so the slider controls G.711 volume too
+        if (this._media_element) {
+            gain.gain.value = this._media_element.muted ? 0 : this._media_element.volume;
+        }
+
+        const sampleCount = pcmaData.length / channelCount;
+        const buf = ctx.createBuffer(channelCount, sampleCount, 8000);
+        const table = PlayerEngineMainThread._PCMA_TABLE;
+
+        for (let ch = 0; ch < channelCount; ch++) {
+            const channelData = buf.getChannelData(ch);
+            for (let i = 0; i < sampleCount; i++) {
+                channelData[i] = table[pcmaData[i * channelCount + ch]] / 32768;
+            }
+        }
+
+        const source = ctx.createBufferSource();
+        source.buffer = buf;
+        source.connect(gain);
+
+        const now = ctx.currentTime;
+        if (this._g711_next_play_time < now) {
+            this._g711_next_play_time = now;
+        }
+        source.start(this._g711_next_play_time);
+        this._g711_next_play_time += buf.duration;
     }
 
 }


### PR DESCRIPTION
## Summary

Surveillance cameras commonly use G.711 PCMA (FLV audio codec index 7), which is unsupported by MSE/SourceBuffer. This PR adds G.711 PCMA playback support by routing audio through the Web Audio API in parallel with the existing MSE video pipeline.

## Changes

- **FLV Demuxer**: Accept codec index 7 (PCMA), parse raw PCMA frames and dispatch via new `onG711AudioData` callback instead of dropping with "Unsupported audio codec idx: 7"
- **Transmuxing pipeline**: Propagate `G711_AUDIO_DATA` event through `TransmuxingController` → `Transmuxer` → player (both main-thread and worker modes)
- **Player Engine**: Decode PCMA→PCM16 via 256-entry lookup table, schedule playback with `AudioContext` (8 kHz) + `GainNode`; gain is synced from the media element's volume/muted state so existing volume controls work transparently
- **Docs**: Update README and README_zh with G.711 support notes

## Why Web Audio API

G.711 PCMA is a logarithmic codec not supported by any browser's MSE implementation. Decoding in JS and feeding an `AudioContext` is the only cross-browser approach, and keeps the video pipeline untouched.